### PR TITLE
Harmonize entry points

### DIFF
--- a/cortex-a-rt/src/lib.rs
+++ b/cortex-a-rt/src/lib.rs
@@ -436,7 +436,7 @@ core::arch::global_asm!(
         b       done
 not_thumb:
         // Subtract 4 from LR (ARM mode)
-	      subs	lr, lr, #4
+        subs    lr, lr, #4
 done:
         // state save from compiled code
         srsfd   sp!, {und_mode}
@@ -552,25 +552,26 @@ core::arch::global_asm!(
     .global _default_start
     .type _default_start, %function
     _default_start:
-
         // only allow cpu0 through for initialization
         // Read MPIDR
-	      mrc	p15,0,r1,c0,c0,5
+        mrc     p15, 0, r1, c0, c0, 5
         // Extract CPU ID bits. For single-core systems, this should always be 0
-	      and	r1, r1, #0x3
-        cmp	r1, #0
-	      beq initialize
-    wait_loop:
+        mov     r2, #0xFFFF
+        and     r1, r1, r2
+        cmp     r1, #0
+        beq     1f
+    0:
         wfe
         // When Core 0 emits a SEV, the other cores will wake up.
-        // Load CPU ID, we are CPU0
-	      mrc	p15,0,r0,c0,c0,5
+        // Load CPU ID.
+        mrc     p15, 0, r0, c0, c0, 5
         // Extract CPU ID bits.
-	      and	r0, r0, #0x3
+        mov     r2, #0xFFFF
+        and     r0, r0, r2
         bl      boot_core
         // Should never returns, loop permanently here.
-        b .
-    initialize:
+        b       .
+    1:
         // Set up stacks.
         ldr     r0, =_stack_top
         // Set stack pointer (right after) and mask interrupts for for UND mode (Mode 0x1B)

--- a/cortex-r-rt/CHANGELOG.md
+++ b/cortex-r-rt/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## Changed
+
+- Entry point renamed from `kmain` to `boot_core`. `boot_core` expects one argument
+  which will be the CPU ID.
+
 ## Added
 
 - Added ABT und UND mode stack setup.

--- a/examples/mps3-an536/src/bin/generic_timer.rs
+++ b/examples/mps3-an536/src/bin/generic_timer.rs
@@ -12,13 +12,17 @@ use semihosting::println;
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
-pub extern "C" fn kmain() {
-    main();
-    semihosting::process::exit(0);
+pub extern "C" fn boot_core(cpu_id: u32) -> ! {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
 }
 
 /// Let's test some timers!
-fn main() {
+fn main() -> ! {
     use cortex_ar::generic_timer::{El1PhysicalTimer, El1VirtualTimer, GenericTimer};
     let cntfrq = cortex_ar::register::Cntfrq::read().0;
     println!("cntfrq = {:.03} MHz", cntfrq as f32 / 1_000_000.0);
@@ -64,4 +68,5 @@ fn main() {
             timer.countdown() as i32
         );
     }
+    semihosting::process::exit(0)
 }

--- a/examples/mps3-an536/src/bin/gic.rs
+++ b/examples/mps3-an536/src/bin/gic.rs
@@ -24,13 +24,18 @@ const GICR_BASE_OFFSET: usize = 0x0010_0000usize;
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
-pub extern "C" fn kmain() {
-    main();
+pub extern "C" fn boot_core(cpu_id: u32) -> ! {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
 }
 
 /// The main function of our Rust application.
 ///
-/// Called by [`kmain`].
+/// Called by [boot_core].
 fn main() -> ! {
     // Get the GIC address by reading CBAR
     let periphbase = cortex_ar::register::ImpCbar::read().periphbase();

--- a/examples/mps3-an536/src/bin/hello.rs
+++ b/examples/mps3-an536/src/bin/hello.rs
@@ -12,13 +12,18 @@ use semihosting::println;
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
-pub extern "C" fn kmain() {
-    main();
+pub extern "C" fn boot_core(cpu_id: u32) -> ! {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
 }
 
 /// The main function of our Rust application.
 ///
-/// Called by [`kmain`].
+/// Called by [boot_core].
 fn main() -> ! {
     let x = 1.0f64;
     let y = x * 2.0;

--- a/examples/mps3-an536/src/bin/registers.rs
+++ b/examples/mps3-an536/src/bin/registers.rs
@@ -12,13 +12,18 @@ use semihosting::println;
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
-pub extern "C" fn kmain() {
-    main();
+pub extern "C" fn boot_core(cpu_id: u32) -> ! {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
 }
 
 /// The entry-point to the Rust application.
 ///
-/// Called by [`kmain`].
+/// Called by [boot_core].
 pub fn main() -> ! {
     chip_info();
     #[cfg(arm_architecture = "v7-r")]

--- a/examples/mps3-an536/src/bin/svc.rs
+++ b/examples/mps3-an536/src/bin/svc.rs
@@ -12,13 +12,18 @@ use semihosting::println;
 ///
 /// It is called by the start-up code in `cortex-m-rt`.
 #[no_mangle]
-pub extern "C" fn kmain() {
-    main();
+pub extern "C" fn boot_core(cpu_id: u32) -> ! {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
 }
 
 /// The main function of our Rust application.
 ///
-/// Called by [`kmain`].
+/// Called by [boot_core].
 pub fn main() -> ! {
     let x = 1;
     let y = x + 1;

--- a/examples/versatileab/reference/hello-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/hello-armv7a-none-eabi.out
@@ -3,7 +3,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/hello.rs",
-        line: 19,
+        line: 30,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/reference/hello-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/hello-armv7r-none-eabi.out
@@ -3,7 +3,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/hello.rs",
-        line: 19,
+        line: 30,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/reference/hello-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/hello-armv7r-none-eabihf.out
@@ -3,7 +3,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/hello.rs",
-        line: 19,
+        line: 30,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/reference/svc-armv7a-none-eabi.out
+++ b/examples/versatileab/reference/svc-armv7a-none-eabi.out
@@ -6,7 +6,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/svc.rs",
-        line: 22,
+        line: 33,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/reference/svc-armv7r-none-eabi.out
+++ b/examples/versatileab/reference/svc-armv7r-none-eabi.out
@@ -6,7 +6,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/svc.rs",
-        line: 22,
+        line: 33,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/reference/svc-armv7r-none-eabihf.out
+++ b/examples/versatileab/reference/svc-armv7r-none-eabihf.out
@@ -6,7 +6,7 @@ PANIC: PanicInfo {
     message: I am an example panic,
     location: Location {
         file: "src/bin/svc.rs",
-        line: 22,
+        line: 33,
         col: 5,
     },
     can_unwind: true,

--- a/examples/versatileab/src/bin/abt-exception.rs
+++ b/examples/versatileab/src/bin/abt-exception.rs
@@ -11,9 +11,20 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
-
 static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in the runtime crate.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The main function of our Rust application.
 #[export_name = "main"]

--- a/examples/versatileab/src/bin/hello.rs
+++ b/examples/versatileab/src/bin/hello.rs
@@ -8,7 +8,18 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in the runtime crate.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The main function of our Rust application.
 #[export_name = "main"]

--- a/examples/versatileab/src/bin/prefetch-exception.rs
+++ b/examples/versatileab/src/bin/prefetch-exception.rs
@@ -11,9 +11,20 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
-
 static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in the runtime crate.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The main function of our Rust application.
 #[export_name = "main"]

--- a/examples/versatileab/src/bin/registers.rs
+++ b/examples/versatileab/src/bin/registers.rs
@@ -8,7 +8,18 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in the runtime crate.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The entry-point to the Rust application.
 ///

--- a/examples/versatileab/src/bin/svc.rs
+++ b/examples/versatileab/src/bin/svc.rs
@@ -8,7 +8,18 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The main function of our Rust application.
 #[export_name = "main"]

--- a/examples/versatileab/src/bin/undef-exception.rs
+++ b/examples/versatileab/src/bin/undef-exception.rs
@@ -10,9 +10,20 @@ use versatileab as _;
 
 use semihosting::println;
 
-versatileab::entry_point!();
-
 static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// The entry-point to the Rust application.
+///
+/// It is called by the start-up code in the runtime crate.
+#[no_mangle]
+pub extern "C" fn boot_core(cpu_id: u32) {
+    match cpu_id {
+        0 => {
+            main();
+        }
+        _ => panic!("unexpected CPU ID {}", cpu_id),
+    }
+}
 
 /// The main function of our Rust application.
 #[export_name = "main"]

--- a/examples/versatileab/src/lib.rs
+++ b/examples/versatileab/src/lib.rs
@@ -11,34 +11,6 @@ use cortex_r_rt as _;
 #[cfg(arm_architecture = "v8-r")]
 compile_error!("This example/board is not compatible with the ARMv8-R architecture");
 
-#[macro_export]
-macro_rules! entry_point {
-    () => {
-        /// The entry-point to the Rust application.
-        ///
-        /// It is called by the start-up code in `cortex-m-rt`.
-        #[no_mangle]
-        #[cfg(arm_profile = "r")]
-        pub extern "C" fn kmain() {
-            main();
-        }
-
-        /// The entry-point to the Rust application.
-        ///
-        /// It is called by the start-up code in `cortex-a-rt`.
-        #[no_mangle]
-        #[cfg(arm_profile = "a")]
-        pub extern "C" fn boot_core(cpu_id: u32) {
-            match cpu_id {
-                0 => {
-                    main();
-                }
-                _ => panic!("unexpected CPU ID {}", cpu_id),
-            }
-        }
-    };
-}
-
 /// Called when the application raises an unrecoverable `panic!`.
 ///
 /// Prints the panic to the console and then exits QEMU using a semihosting


### PR DESCRIPTION
One thing I am not sure about is how to best determine the CPU ID. The MPIDR register is implementation defined, and the individual affinity fields might have completely different meanings depending on the actual implementation (https://developer.arm.com/documentation/ddi0406/b/System-Level-Architecture/Virtual-Memory-System-Architecture--VMSA-/CP15-registers-for-a-VMSA-implementation/c0--Multiprocessor-Affinity-Register--MPIDR-?lang=en#CIHIEGCJ) . The previous implementation in the Cortex-A run-time, which reads the least significant 2 bits of affinity 0, was just the Zynq7000 specific implementation of the MPIDR register. I replaced this with reading all the bits in affinity 0 as well.

Should we still keep this implementation where we assume that a value of 0 in affinity 0 field means CPU 0? 