### PR TITLE
Removed mutable borrow in readonly generic timer methods

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/cortex-ar/src/generic_timer/el0.rs
+++ b/cortex-ar/src/generic_timer/el0.rs
@@ -30,11 +30,11 @@ impl super::GenericTimer for El0PhysicalTimer {
         register::Cntfrq::read().0
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         register::CntPct::read().0
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         register::CntpCval::read().0
     }
 
@@ -94,11 +94,11 @@ impl super::GenericTimer for El0VirtualTimer {
         register::Cntfrq::read().0
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         register::CntVct::read().0
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         register::CntvCval::read().0
     }
 

--- a/cortex-ar/src/generic_timer/el1.rs
+++ b/cortex-ar/src/generic_timer/el1.rs
@@ -38,11 +38,11 @@ impl GenericTimer for El1PhysicalTimer {
         self.0.frequency_hz()
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         self.0.counter()
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         self.0.counter_compare()
     }
 
@@ -138,11 +138,11 @@ impl GenericTimer for El1VirtualTimer {
         self.0.frequency_hz()
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         self.0.counter()
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         self.0.counter_compare()
     }
 

--- a/cortex-ar/src/generic_timer/el2.rs
+++ b/cortex-ar/src/generic_timer/el2.rs
@@ -34,11 +34,11 @@ impl GenericTimer for El2PhysicalTimer {
         self.0.frequency_hz()
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         self.0.counter()
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         self.0.counter_compare()
     }
 
@@ -105,11 +105,11 @@ impl GenericTimer for El2VirtualTimer {
         self.0.frequency_hz()
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         self.0.counter()
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         self.0.counter_compare()
     }
 
@@ -166,11 +166,11 @@ impl super::GenericTimer for El2HypPhysicalTimer {
         register::Cntfrq::read().0
     }
 
-    fn counter(&mut self) -> u64 {
+    fn counter(&self) -> u64 {
         register::CntPct::read().0
     }
 
-    fn counter_compare(&mut self) -> u64 {
+    fn counter_compare(&self) -> u64 {
         register::CnthpCval::read().0
     }
 

--- a/cortex-ar/src/generic_timer/mod.rs
+++ b/cortex-ar/src/generic_timer/mod.rs
@@ -28,10 +28,10 @@ pub trait GenericTimer {
     ///
     /// Note that speculative reads are allowed and reads may occur out of
     /// order. Add ISB and DSB fences before/after this call as required.
-    fn counter(&mut self) -> u64;
+    fn counter(&self) -> u64;
 
     /// Get the counter compare value.
-    fn counter_compare(&mut self) -> u64;
+    fn counter_compare(&self) -> u64;
 
     /// Set the counter compare value.
     ///


### PR DESCRIPTION
Namely:
- counter
- counter_compare

Also, enforced lf ending on shell scripts via gitattributes.