### PR TITLE
Prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ These libraries were originally written by Ferrous Systems, and are based on the
 [`cortex-m` libraries]: https://github.com/rust-embedded/cortex-m
 [Rust Embedded Devices Working Group]: https://github.com/rust-embedded
 
-There are currently three libraries here:
+There are currently five libraries here:
 
 * [cortex-ar](./cortex-ar/) - support library for Cortex-R and Cortex-A CPUs (like [cortex-m])
 * [cortex-r-rt](./cortex-r-rt/) - run-time library for Cortex-R CPUs (like [cortex-m-rt])
 * [cortex-a-rt](./cortex-a-rt/) - run-time library for Cortex-A CPUs (like [cortex-m-rt])
 * [arm-targets](./arm-targets/) - a helper library for your build.rs that sets various `--cfg` flags according to the current target
+* [cortex-ar-rt-macros](./cortex-ar-rt-macros/) - macros for `cortex-a-rt` and `cortex-r-rt` (this is an implementation detail - do not use this crate directly)
 
 There are also example programs for QEMU in the [examples](./examples/) folder.
 

--- a/arm-targets/CHANGELOG.md
+++ b/arm-targets/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+No changes
+
+## [v0.2.0]
+
+### Added
+
+* `TargetInfo` struct
+* Armv7-A support
+
+### Changed
+
+* The `process_target` function returns a `TargetInfo`
+
+## [v0.1.0]
+
+Initial release
+
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.1.0...HEAD
+[v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.1.0...arm-targets-v0.2.0
+[v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/arm-targets-v0.1.0

--- a/arm-targets/CHANGELOG.md
+++ b/arm-targets/CHANGELOG.md
@@ -24,6 +24,6 @@ No changes
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.2.0...HEAD
 [v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.1.0...arm-targets-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/arm-targets-v0.1.0

--- a/arm-targets/Cargo.toml
+++ b/arm-targets/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.59"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]

--- a/arm-targets/Cargo.toml
+++ b/arm-targets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = [
     "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
-    "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"
+    "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
 ]
 categories = ["development-tools::build-utils"]
 description = "Compile-time feature detection for Arm processors"

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -29,8 +29,12 @@ This allows you to write Rust code in your firmware like:
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.59.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`.
+
+Increasing the MSRV is not considered a breaking change and may occur in a
+minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
+`0.x` release).
 
 ## Licence
 

--- a/arm-targets/README.md
+++ b/arm-targets/README.md
@@ -34,7 +34,8 @@ compile with older versions but that may change in any new patch release.
 
 ## Licence
 
-Copyright (c) Ferrous Systems, 2025
+* Copyright (c) Ferrous Systems
+* Copyright (c) The Rust Embedded Devices Working Group developers
 
 Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
 your option.

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -2,7 +2,7 @@
 authors = [
   "Robin Mueller <muellerr@irs.uni-stuttgart.de>",
   "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
-  "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"
+  "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
 ]
 description = "Run-Time support for Arm Cortex-A"
 edition = "2021"

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.82"
 version = "0.1.0"
 
 [dependencies]
-cortex-ar = {version = "0.1.0", path = "../cortex-ar"}
+cortex-ar = {version = "0.2.0", path = "../cortex-ar"}
 cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.0" }
 
 [features]
@@ -26,7 +26,7 @@ eabi-fpu = []
 vfp-dp = []
 
 [build-dependencies]
-arm-targets = {version = "0.1.0", path = "../arm-targets"}
+arm-targets = {version = "0.2.0", path = "../arm-targets"}
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabihf"]

--- a/cortex-a-rt/README.md
+++ b/cortex-a-rt/README.md
@@ -1,4 +1,11 @@
-# Arm Cortex-A Run-Time
+# Run-time support for Arm Cortex-A (AArch32)
+
+This library implements a simple Arm vector table, suitable for getting into a
+Rust application running in System Mode. It also provides a reference start
+up method. Most Cortex-A based systems will require chip specific start-up
+code, so the start-up method can over overriden.
+
+See <https://docs.rs/cortex-a-rt> for detailed documentation.
 
 ## Features
 

--- a/cortex-a-rt/README.md
+++ b/cortex-a-rt/README.md
@@ -8,8 +8,12 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`.
+
+Increasing the MSRV is not considered a breaking change and may occur in a
+minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
+`0.x` release).
 
 ## Licence
 

--- a/cortex-a-rt/README.md
+++ b/cortex-a-rt/README.md
@@ -3,7 +3,7 @@
 This library implements a simple Arm vector table, suitable for getting into a
 Rust application running in System Mode. It also provides a reference start
 up method. Most Cortex-A based systems will require chip specific start-up
-code, so the start-up method can over overriden.
+code, so the start-up method can over overridden.
 
 See <https://docs.rs/cortex-a-rt> for detailed documentation.
 

--- a/cortex-a-rt/src/lib.rs
+++ b/cortex-a-rt/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library implements a simple Arm vector table, suitable for getting into
 //! a Rust application running in System Mode. It also provides a reference
 //! start up method. Most Cortex-A based systems will require chip specific
-//! start-up code, so the start-up method can over overriden.
+//! start-up code, so the start-up method can over overridden.
 //!
 //! The default startup routine provided by this crate does not include any
 //! special handling for multi-core support because this is oftentimes

--- a/cortex-ar-rt-macros/CHANGELOG.md
+++ b/cortex-ar-rt-macros/CHANGELOG.md
@@ -13,5 +13,5 @@ No changes
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-a-rt-v0.1.0...HEAD
-[v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-a-rt-v0.1.0
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-rt-macros-v0.1.0...HEAD
+[v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-ar-rt-macros-v0.1.0

--- a/cortex-ar-rt-macros/Cargo.toml
+++ b/cortex-ar-rt-macros/Cargo.toml
@@ -2,7 +2,7 @@
 authors = [
   "Robin Mueller <muellerr@irs.uni-stuttgart.de>",
   "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
-  "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"
+  "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
 ]
 description = "Run-Time macros for Arm Cortex-A and Cortex-R"
 edition = "2021"

--- a/cortex-ar-rt-macros/README.md
+++ b/cortex-ar-rt-macros/README.md
@@ -10,8 +10,12 @@ This crate contains proc-macros that are re-exported through the following crate
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`.
+
+Increasing the MSRV is not considered a breaking change and may occur in a
+minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
+`0.x` release).
 
 ## Licence
 

--- a/cortex-ar-rt-macros/README.md
+++ b/cortex-ar-rt-macros/README.md
@@ -1,0 +1,28 @@
+# Macros for `cortex-a-rt` and `cortex-r-rt`
+
+This crate contains proc-macros that are re-exported through the following crates:
+
+* [`cortex-a-rt`]
+* [`cortex-r-rt`]
+
+[cortex-a-rt]: https://crates.io/crates/cortex-a-rt
+[cortex-r-rt]: https://crates.io/crates/cortex-r-rt
+
+## Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
+compile with older versions but that may change in any new patch release.
+
+## Licence
+
+* Copyright (c) Ferrous Systems
+* Copyright (c) The Rust Embedded Devices Working Group developers
+
+Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
+your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you shall be licensed as above, without any
+additional terms or conditions.

--- a/cortex-ar/CHANGELOG.md
+++ b/cortex-ar/CHANGELOG.md
@@ -5,18 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [Unreleased]
+
+## [v0.2.0]
 
 ### Added
 
 - General support for the Cortex-A architecture.
 - New `sev` function in ASM module.
-- Compiler fences for `dsb` and `isb`
+- Added multi-core-safe critical-section implementation
+- Additional EL1 MPU methods `set_region`, `set_attributes` and `background_region_enable`
+
+### Changed
+
+- Timer methods only need `&self` not `&mut self`
+- The `dsb` and `isb` functions now include compiler fences
 - Added `nomem`, `nostack` and `preserves_flags` options for ASM where applicable.
 
 ## [v0.1.0]
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.2.0...HEAD
+[v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.1.0...cortex-ar-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-ar-v0.1.0

--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = [
     "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
-    "The Cortex-R Team <cortex-r@teams.rust-embedded.org>",
+    "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>",
 ]
 categories = [
     "embedded",

--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.82"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 arbitrary-int = "1.3.0"
@@ -32,7 +32,7 @@ critical-section = {version = "1.2.0", features = ["restore-state-u8"], optional
 defmt = {version = "0.3", optional = true}
 
 [build-dependencies]
-arm-targets = {version = "0.1.0", path = "../arm-targets"}
+arm-targets = {version = "0.2.0", path = "../arm-targets"}
 
 [features]
 # Adds a critical-section implementation that only disables interrupts.

--- a/cortex-ar/README.md
+++ b/cortex-ar/README.md
@@ -22,8 +22,12 @@ If you need a driver for the Arm Generic Interrupt Controller, see
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`.
+
+Increasing the MSRV is not considered a breaking change and may occur in a
+minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
+`0.x` release).
 
 ## Licence
 

--- a/cortex-ar/README.md
+++ b/cortex-ar/README.md
@@ -27,7 +27,8 @@ compile with older versions but that may change in any new patch release.
 
 ## Licence
 
-Copyright (c) Ferrous Systems, 2025
+* Copyright (c) Ferrous Systems
+* Copyright (c) The Rust Embedded Devices Working Group developers
 
 Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
 your option.

--- a/cortex-r-rt/CHANGELOG.md
+++ b/cortex-r-rt/CHANGELOG.md
@@ -5,20 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [Unreleased]
+
+## [v0.2.0]
 
 ## Added
 
 - Added ABT und UND mode stack setup.
-- Default exception handlers for undefined, prefetch and data abort exceptions
+- Default exception handlers for undefined, prefetch abort and data abort exceptions
+- SMP support
+- Zeroing of registers on start-up
+- `#[entry]` and `#[exception]` and `#[interrupt]` macros
 
 ## Changed
 
+- Fixed interrupt handler so interrupts can be re-entrant
 - Default Rust exception handler is now an empty permanent loop instead of a semihosting exit.
+- The SVC asm trampoline can now be over-ridden
+- The Undefined, Prefetch and Abort handlers can either return never, or can return a new address to continue executing from when the handler is over
 
 ## [v0.1.0]
 
 Initial release
 
-[unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.2.0...HEAD
+[v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.1.0...cortex-r-rt-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-r-rt-v0.1.0

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -21,19 +21,19 @@ name = "cortex-r-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-r.git"
 rust-version = "1.82"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
-cortex-ar = {version = "0.1.0", path = "../cortex-ar"}
+cortex-ar = {version = "0.2.0", path = "../cortex-ar"}
 semihosting = {version = "0.1.18", features = ["stdio"]}
-cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.0" }
+cortex-ar-rt-macros = {path = "../cortex-ar-rt-macros", version = "=0.1.0"}
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target
 eabi-fpu = []
 
 [build-dependencies]
-arm-targets = {version = "0.1.0", path = "../arm-targets"}
+arm-targets = {version = "0.2.0", path = "../arm-targets"}
 
 [package.metadata.docs.rs]
 targets = ["armv7r-none-eabihf", "armv7r-none-eabihf"]

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = [
     "Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
-    "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"
+    "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
 ]
 categories = [
     "embedded",

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -1,4 +1,11 @@
-# Arm Cortex-R Run-Time
+# Run-time support for Arm Cortex-R (AArch32)
+
+This library implements a simple Arm vector table, suitable for getting into a
+Rust application running in System Mode. It also provides a reference start
+up method. Most Cortex-R based systems will require chip specific start-up
+code, so the start-up method can over overriden.
+
+See <https://docs.rs/cortex-r-rt> for detailed documentation.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -2,8 +2,12 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`.
+
+Increasing the MSRV is not considered a breaking change and may occur in a
+minor version release (e.g. from `0.3.0` to `0.3.1`, because this is still a
+`0.x` release).
 
 ## Licence
 

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -7,7 +7,8 @@ compile with older versions but that may change in any new patch release.
 
 ## Licence
 
-Copyright (c) Ferrous Systems, 2025
+* Copyright (c) Ferrous Systems
+* Copyright (c) The Rust Embedded Devices Working Group developers
 
 Licensed under either [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at
 your option.

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -3,7 +3,7 @@
 This library implements a simple Arm vector table, suitable for getting into a
 Rust application running in System Mode. It also provides a reference start
 up method. Most Cortex-R based systems will require chip specific start-up
-code, so the start-up method can over overriden.
+code, so the start-up method can over overridden.
 
 See <https://docs.rs/cortex-r-rt> for detailed documentation.
 

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library implements a simple Arm vector table, suitable for getting into
 //! a Rust application running in System Mode. It also provides a reference
 //! start up method. Most Cortex-R based systems will require chip specific
-//! start-up code, so the start-up method can over overriden.
+//! start-up code, so the start-up method can over overridden.
 //!
 //! The default startup routine provided by this crate does not include any
 //! special handling for multi-core support because this is oftentimes

--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -19,7 +19,7 @@ arm-gic = { git = "https://github.com/google/arm-gic.git", rev = "46a8fc1720f5c2
 critical-section = "1.2.0"
 
 [build-dependencies]
-arm-targets = {version = "0.1.0", path = "../../arm-targets"}
+arm-targets = {version = "0.2.0", path = "../../arm-targets"}
 
 [features]
 eabi-fpu = ["cortex-r-rt/eabi-fpu"]

--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
-authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"]
+authors = [
+	"Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
+	"The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
+]
 default-run = "hello"
-edition = "2021"
-name = "mps3-an536"
 description = "Examples for MPS3-AN536 device (Arm Cortex-R)"
+edition = "2021"
+homepage = "https://github.com/rust-embedded/cortex-ar.git"
 license = "MIT OR Apache-2.0"
+name = "mps3-an536"
+publish = false
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
-homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.82"
-version = "0.1.0"
+version = "0.0.0"
 
 [dependencies]
 cortex-ar = { path = "../../cortex-ar", features = ["critical-section-multi-core"] }

--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"]
+authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"]
 default-run = "hello"
 edition = "2021"
 name = "mps3-an536"

--- a/examples/mps3-an536/README.md
+++ b/examples/mps3-an536/README.md
@@ -2,8 +2,9 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`. These examples are
+not version controlled and we may change the MSRV at any time.
 
 ## Licence
 

--- a/examples/mps3-an536/README.md
+++ b/examples/mps3-an536/README.md
@@ -1,4 +1,18 @@
-# Examples for Arm Cortex-R
+# Examples for Arm MPS3-AN536
+
+This package contains example binaries for the Arm MPS3-AN536 evaluation
+system, featuring one or two Arm Cortex-R52 processor cores. This crate
+should be compiled for the `armv8r-none-eabihf` target. The repo-level
+[`.cargo/config.toml`] will ensure the code runs on the appropriate QEMU
+configuration.
+
+As of Rust 1.87, `armv8r-none-eabihf` is a Tier 3 target and so these examples
+require Nightly Rust.
+
+We have only tested this crate on `qemu-system-arm` emulating the Arm
+MPS3-AN536, not the real thing.
+
+[`.cargo/config.toml`]: ../../.cargo/config.toml
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -18,7 +18,7 @@ cortex-r-rt = { path = "../../cortex-r-rt" }
 semihosting = { version = "0.1.18", features = ["stdio"] }
 
 [build-dependencies]
-arm-targets = { version = "0.1.0", path = "../../arm-targets" }
+arm-targets = { version = "0.2.0", path = "../../arm-targets" }
 
 [features]
 eabi-fpu = ["cortex-a-rt/eabi-fpu", "cortex-r-rt/eabi-fpu"]

--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Cortex-R Team <cortex-r@teams.rust-embedded.org>"]
+authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"]
 default-run = "hello"
 edition = "2021"
 name = "versatileab"

--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
-authors = ["Jonathan Pallant <jonathan.pallant@ferrous-systems.com>", "The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"]
+authors = [
+	"Jonathan Pallant <jonathan.pallant@ferrous-systems.com>",
+	"The Embedded Devices Working Group Arm Team <arm@teams.rust-embedded.org>"
+]
 default-run = "hello"
+description = "Examples for the QEMU Versatile Application baseboard device (Arm Cortex-A8 or Arm Cortex-R5)"
 edition = "2021"
-name = "versatileab"
-description = "Examples for the QEMU Versatile baseboard device (Arm Cortex-A)"
+homepage = "https://github.com/rust-embedded/cortex-ar.git"
 license = "MIT OR Apache-2.0"
+name = "versatileab"
+publish = false
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
-homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.82"
-version = "0.1.0"
+version = "0.0.0"
 
 [dependencies]
 cortex-ar = { path = "../../cortex-ar", features = ["critical-section-single-core"] }

--- a/examples/versatileab/README.md
+++ b/examples/versatileab/README.md
@@ -2,8 +2,9 @@
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.82.0 and up. It *might*
-compile with older versions but that may change in any new patch release.
+This crate is guaranteed to compile on stable Rust 1.82.0 and up, as recorded
+by the `package.rust-version` property in `Cargo.toml`. These examples are
+not version controlled and we may change the MSRV at any time.
 
 ## Licence
 

--- a/examples/versatileab/README.md
+++ b/examples/versatileab/README.md
@@ -1,4 +1,16 @@
-# Examples for Arm Cortex-R
+# Examples for Arm Versatile Application Board
+
+This package contains example binaries for the Arm Versatile Application
+baseboard evaluation system, featuring an Arm Cortex-R5 processor or Arm
+Cortex-A8 processor core. This crate should be compiled for the
+`armv7r-none-eabihf`, `armv7r-none-eabi`, `armv7a-none-eabi` or
+`armv7a-none-eabihf` targets. The repo-level [`.cargo/config.toml`] will
+ensure the code runs on the appropriate QEMU configuration.
+
+We have only tested this crate on `qemu-system-arm` emulating the Arm
+Versatile Application Board, not the real thing.
+
+[`.cargo/config.toml`]: ../../.cargo/config.toml
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/examples/versatileab/config.toml
+++ b/examples/versatileab/config.toml
@@ -1,2 +1,0 @@
-[build]
-target = ["armv7r-none-eabihf"]


### PR DESCRIPTION
Prepares for:

* arm-targets v0.2.0 (was v0.1.0)
* cortex-ar v0.2.0 (was v0.1.0)
* cortex-ar-rt-macros v0.1.0 (new)
* cortex-a-rt v0.1.0 (new)
* cortex-r-rt v0.2.0 (was v0.1.0)

We should publish in that order (due to dependencies).
