### PR TITLE
fix typo

### DIFF
--- a/cortex-a-rt/README.md
+++ b/cortex-a-rt/README.md
@@ -3,7 +3,7 @@
 This library implements a simple Arm vector table, suitable for getting into a
 Rust application running in System Mode. It also provides a reference start
 up method. Most Cortex-A based systems will require chip specific start-up
-code, so the start-up method can over overridden.
+code, so the start-up method can be overridden.
 
 See <https://docs.rs/cortex-a-rt> for detailed documentation.
 

--- a/cortex-a-rt/src/lib.rs
+++ b/cortex-a-rt/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library implements a simple Arm vector table, suitable for getting into
 //! a Rust application running in System Mode. It also provides a reference
 //! start up method. Most Cortex-A based systems will require chip specific
-//! start-up code, so the start-up method can over overridden.
+//! start-up code, so the start-up method can be overridden.
 //!
 //! The default startup routine provided by this crate does not include any
 //! special handling for multi-core support because this is oftentimes
@@ -122,7 +122,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! or:
 //!
 //! ```rust
@@ -149,7 +149,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! or:
 //!
 //! ```rust
@@ -220,7 +220,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! Or it can return an address where execution should resume after the
 //! Exception handler is complete (which is unsafe):
 //!
@@ -278,7 +278,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! Or it can return an address where execution should resume after the
 //! Exception handler is complete (which is unsafe):
 //!
@@ -645,7 +645,7 @@ macro_rules! restore_context {
 #[cfg(target_arch = "arm")]
 core::arch::global_asm!(
     r#"
-       
+
     // Called from the vector table when we have an undefined exception.
     // Saves state and calls a C-compatible handler like
     // `extern "C" fn _undefined_handler(addr: usize) -> usize;`

--- a/cortex-r-rt/README.md
+++ b/cortex-r-rt/README.md
@@ -3,7 +3,7 @@
 This library implements a simple Arm vector table, suitable for getting into a
 Rust application running in System Mode. It also provides a reference start
 up method. Most Cortex-R based systems will require chip specific start-up
-code, so the start-up method can over overridden.
+code, so the start-up method can be overridden.
 
 See <https://docs.rs/cortex-r-rt> for detailed documentation.
 

--- a/cortex-r-rt/src/lib.rs
+++ b/cortex-r-rt/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library implements a simple Arm vector table, suitable for getting into
 //! a Rust application running in System Mode. It also provides a reference
 //! start up method. Most Cortex-R based systems will require chip specific
-//! start-up code, so the start-up method can over overridden.
+//! start-up code, so the start-up method can be overridden.
 //!
 //! The default startup routine provided by this crate does not include any
 //! special handling for multi-core support because this is oftentimes
@@ -121,7 +121,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! or:
 //!
 //! ```rust
@@ -148,7 +148,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! or:
 //!
 //! ```rust
@@ -219,7 +219,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! Or it can return an address where execution should resume after the
 //! Exception handler is complete (which is unsafe):
 //!
@@ -277,7 +277,7 @@
 //!     loop { }
 //! }
 //! ```
-//!   
+//!
 //! Or it can return an address where execution should resume after the
 //! Exception handler is complete (which is unsafe):
 //!
@@ -580,7 +580,7 @@ core::arch::global_asm!(
     r#"
     // Work around https://github.com/rust-lang/rust/issues/127269
     .fpu vfp3-d16
-       
+
     // Called from the vector table when we have an undefined exception.
     // Saves state and calls a C-compatible handler like
     // `extern "C" fn _undefined_handler(addr: usize) -> usize;`


### PR DESCRIPTION
Replace `can over overridden` with `can be overridden`.