### PR TITLE
fix bit position for non-global bit in L1 section

### DIFF
--- a/cortex-ar/src/mmu.rs
+++ b/cortex-ar/src/mmu.rs
@@ -143,7 +143,7 @@ pub struct L1Section {
     #[bits(20..=31, rw)]
     base_addr: u12,
     /// Non-global bit.
-    #[bit(16, rw)]
+    #[bit(17, rw)]
     ng: bool,
     /// Shareable bit.
     #[bit(16, rw)]


### PR DESCRIPTION
Previously had same bit position are shareable bit