### PR TITLE
New releases of everything

### DIFF
--- a/arm-targets/CHANGELOG.md
+++ b/arm-targets/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.0]
+
 ### Added
 
-- Added support for legacy Arm targets: Armv5TE and Armv4T, including proper arch, isa, and profile handling.
+- Support for legacy Arm targets: Armv5TE and Armv4T
+- Additional documentation
+- ABI type (either EABI or EABIHF)
+- Simple CLI tool
+- Some unit tests
 
 ## [v0.2.0]
 
@@ -26,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.2.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.3.0...HEAD
+[v0.3.0]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.2.0...arm-targets-v0.3.0
 [v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/arm-targets-v0.1.0...arm-targets-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/arm-targets-v0.1.0

--- a/arm-targets/Cargo.toml
+++ b/arm-targets/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.59"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]

--- a/cortex-a-rt/CHANGELOG.md
+++ b/cortex-a-rt/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No changes
+## [v0.1.2]
+
+### Changed
+
+- MSRV is now Rust 1.83
+- Uses cortex-ar 0.3
 
 ## [v0.1.1]
 

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.1.1"
 
 [dependencies]
 cortex-ar = { version = "0.3.0", path = "../cortex-ar" }
-cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.0" }
+cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.1" }
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.83"
 version = "0.1.1"
 
 [dependencies]
-cortex-ar = {version = "0.2.0", path = "../cortex-ar"}
+cortex-ar = { version = "0.3.0", path = "../cortex-ar" }
 cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.0" }
 
 [features]

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.83"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 cortex-ar = { version = "0.3.0", path = "../cortex-ar" }

--- a/cortex-a-rt/Cargo.toml
+++ b/cortex-a-rt/Cargo.toml
@@ -26,7 +26,7 @@ eabi-fpu = []
 vfp-dp = []
 
 [build-dependencies]
-arm-targets = {version = "0.2.0", path = "../arm-targets"}
+arm-targets = { version = "0.3.0", path = "../arm-targets" }
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"]

--- a/cortex-ar-rt-macros/CHANGELOG.md
+++ b/cortex-ar-rt-macros/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-No changes
+## [v0.1.1]
+
+- Correctly note MSRV as 1.83
 
 ## [v0.1.0]
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-rt-macros-v0.1.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-rt-macros-v0.1.1...HEAD
+[v0.1.1]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-rt-macros-v0.1.0...cortex-ar-rt-macros-v0.1.1
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-ar-rt-macros-v0.1.0

--- a/cortex-ar-rt-macros/Cargo.toml
+++ b/cortex-ar-rt-macros/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.83"
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 proc-macro = true

--- a/cortex-ar/CHANGELOG.md
+++ b/cortex-ar/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.3.0]
+
 - Bumped MSRV for `cortex-ar` to v1.83 to allow compatibility with `arbitrary-int` v2.
 
 ### Added
 
 - `dmb` data memory barrier in ASM module.
-- API for inner cache maintenance as part of the new `cache` module. This includes functions to
-  completely clean, invalidate or clean & invalidate the L1 data cache or perform data cache
-  maintenance by MVA (specific address).
-- Added new  `L1Section::set_section_attrs` and `L1Section::section_attrs` method. Also added
-  low-level `L1Section::new_with_addr_upper_bits_and_attrs` constructor.
+- API for inner cache maintenance as part of the new `cache` module. This
+  includes functions to completely clean, invalidate or clean & invalidate the
+  L1 data cache or perform data cache maintenance by MVA (specific address).
+- new  `L1Section::set_section_attrs` and `L1Section::section_attrs` method,
+  and low-level `L1Section::new_with_addr_upper_bits_and_attrs` constructor
+- `Debug`, `Copy`, `Clone` derives for all system register types
 - optional `serde` derives behind a `serde` feature gate
-- lots of missing `Debug`, `Copy`, `Clone`, `defmt::Format` derives.
+- optional `defmt::Format` derives behind a `defmt` feature gate
 
 ### Changed
 
@@ -46,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.2.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.3.0...HEAD
+[v0.3.0]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.2.0...cortex-ar-v0.3.0
 [v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/cortex-ar-v0.1.0...cortex-ar-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-ar-v0.1.0

--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-ar.git"
 homepage = "https://github.com/rust-embedded/cortex-ar.git"
 rust-version = "1.83"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 arbitrary-int = "2"

--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -34,7 +34,7 @@ defmt = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], default-features = false, optional = true }
 
 [build-dependencies]
-arm-targets = {version = "0.2.0", path = "../arm-targets"}
+arm-targets = { version = "0.3.0", path = "../arm-targets" }
 
 [features]
 # Adds a critical-section implementation that only disables interrupts.

--- a/cortex-r-rt/CHANGELOG.md
+++ b/cortex-r-rt/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- No changes
+
+## [v0.2.1]
+
+### Changed
+
+- MSRV is now Rust 1.83
+- Uses cortex-ar 0.3
+
 ## [v0.2.0]
 
-## Added
+### Added
 
 - Added ABT und UND mode stack setup.
 - Default exception handlers for undefined, prefetch abort and data abort exceptions
@@ -17,7 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Zeroing of registers on start-up
 - `#[entry]` and `#[exception]` and `#[interrupt]` macros
 
-## Changed
+### Changed
 
 - Fixed interrupt handler so interrupts can be re-entrant
 - Default Rust exception handler is now an empty permanent loop instead of a semihosting exit.
@@ -28,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.2.0...HEAD
+[Unreleased]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.2.1...HEAD
+[v0.2.1]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.2.0...cortex-r-rt-v0.2.1
 [v0.2.0]: https://github.com/rust-embedded/cortex-ar/compare/cortex-r-rt-v0.1.0...cortex-r-rt-v0.2.0
 [v0.1.0]: https://github.com/rust-embedded/cortex-ar/releases/tag/cortex-r-rt-v0.1.0

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -24,7 +24,7 @@ rust-version = "1.83"
 version = "0.2.0"
 
 [dependencies]
-cortex-ar = {version = "0.2.0", path = "../cortex-ar"}
+cortex-ar = { version = "0.3.0", path = "../cortex-ar" }
 cortex-ar-rt-macros = {path = "../cortex-ar-rt-macros", version = "=0.1.0"}
 
 [features]

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -21,7 +21,7 @@ name = "cortex-r-rt"
 readme = "README.md"
 repository = "https://github.com/rust-embedded/cortex-r.git"
 rust-version = "1.83"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 cortex-ar = { version = "0.3.0", path = "../cortex-ar" }

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -32,7 +32,7 @@ cortex-ar-rt-macros = {path = "../cortex-ar-rt-macros", version = "=0.1.0"}
 eabi-fpu = []
 
 [build-dependencies]
-arm-targets = {version = "0.2.0", path = "../arm-targets"}
+arm-targets = { version = "0.3.0", path = "../arm-targets" }
 
 [package.metadata.docs.rs]
 targets = ["armv7r-none-eabihf", "armv7r-none-eabihf"]

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.2.0"
 
 [dependencies]
 cortex-ar = { version = "0.3.0", path = "../cortex-ar" }
-cortex-ar-rt-macros = {path = "../cortex-ar-rt-macros", version = "=0.1.0"}
+cortex-ar-rt-macros = { path = "../cortex-ar-rt-macros", version = "=0.1.1" }
 
 [features]
 # Enable the FPU on start-up, even on a soft-float EABI target

--- a/examples/mps3-an536/Cargo.toml
+++ b/examples/mps3-an536/Cargo.toml
@@ -24,7 +24,7 @@ critical-section = "1.2.0"
 heapless = "0.9.1"
 
 [build-dependencies]
-arm-targets = {version = "0.2.0", path = "../../arm-targets"}
+arm-targets = {version = "0.3.0", path = "../../arm-targets"}
 
 [features]
 eabi-fpu = ["cortex-r-rt/eabi-fpu"]

--- a/examples/versatileab/Cargo.toml
+++ b/examples/versatileab/Cargo.toml
@@ -22,7 +22,7 @@ cortex-r-rt = { path = "../../cortex-r-rt" }
 semihosting = { version = "0.1.18", features = ["stdio"] }
 
 [build-dependencies]
-arm-targets = { version = "0.2.0", path = "../../arm-targets" }
+arm-targets = { version = "0.3.0", path = "../../arm-targets" }
 
 [features]
 eabi-fpu = ["cortex-a-rt/eabi-fpu", "cortex-r-rt/eabi-fpu"]


### PR DESCRIPTION
* arm-targets is now 0.3.0
* cortex-ar is now 0.3.0
* cortex-ar-rt-macros is now 0.1.1
* cortex-r-rt is now 0.2.1
* cortex-a-rt is now 0.1.2
