### PR TITLE
Update REAMDE to add legacy supported Arm processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust on Arm Cortex-R and Cortex-A
 
 This repository provides support for:
-
+* Legacy Armv4T processors, and Armv5TE
 * Armv7-R Processors, like the Arm Cortex-R5
 * Armv8-R AArch32 Processors, like the Arm Cortex-R52
 * Armv7-A Processors, like the Arm Cortex-A5


### PR DESCRIPTION
Previously I had made a PR that added support for Armv4T and Armv5TE legacy processors, but the README doesn't mention that these are also supported, this PR makes it clear by updating the README to mention these. (The PR referrenced here is #61) 

I apologize for a small and late PR.